### PR TITLE
Use YAML-configured record and thread counts in benchmarks

### DIFF
--- a/src/main/java/com/benchmarking/dbcomparison/benchmark/concurrency/MultiThreadedReadTest.java
+++ b/src/main/java/com/benchmarking/dbcomparison/benchmark/concurrency/MultiThreadedReadTest.java
@@ -32,15 +32,17 @@ public class MultiThreadedReadTest {
     private BenchmarkConfig benchmarkConfig;
 
     void testMultiThreadedRead() throws InterruptedException {
-        int threadCount = benchmarkConfig.getThreads();
+        int configuredThreads = Math.max(1, benchmarkConfig.getThreads());
         int totalRecords = benchmarkConfig.getRecordCount();
-        log.info("Rozpoczynam test wielowątkowego ODCZYTU ({} wątków)", threadCount);
 
         List<Customer> allCustomers = customerRepository.findAll();
         if (allCustomers.size() < totalRecords) {
             log.warn("Brak wystarczającej liczby rekordów do testu, znaleziono: {}", allCustomers.size());
             return;
         }
+
+        int threadCount = Math.min(configuredThreads, totalRecords);
+        log.info("Rozpoczynam test wielowątkowego ODCZYTU ({} wątków)", threadCount);
 
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
@@ -49,11 +51,12 @@ public class MultiThreadedReadTest {
         CopyOnWriteArrayList<Long> threadDurations = new CopyOnWriteArrayList<>();
 
         long startTime = System.nanoTime();
-        int recordsPerThread = totalRecords / threadCount;
+        int base = totalRecords / threadCount;
+        int remainder = totalRecords % threadCount;
 
         for (int i = 0; i < threadCount; i++) {
-            int startIdx = i * recordsPerThread;
-            int endIdx = startIdx + recordsPerThread;
+            int startIdx = i * base + Math.min(i, remainder);
+            int endIdx = startIdx + base + (i < remainder ? 1 : 0);
             List<Customer> customersSlice = allCustomers.subList(startIdx, endIdx);
 
             executor.submit(() -> {

--- a/src/main/java/com/benchmarking/dbcomparison/benchmark/concurrency/MultiThreadedUpdateTest.java
+++ b/src/main/java/com/benchmarking/dbcomparison/benchmark/concurrency/MultiThreadedUpdateTest.java
@@ -1,5 +1,6 @@
 package com.benchmarking.dbcomparison.benchmark.concurrency;
 
+import com.benchmarking.dbcomparison.config.BenchmarkConfig;
 import com.benchmarking.dbcomparison.config.DatabaseMetrics;
 import com.benchmarking.dbcomparison.model.Customer;
 import com.benchmarking.dbcomparison.repository.CustomerRepository;
@@ -21,8 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Component
 public class MultiThreadedUpdateTest {
 
-    private static final int TOTAL_RECORDS = 1000;
-    private static final int THREAD_COUNT = 10;
     private static final String METRIC_NAME = "customer_multithreaded_update";
     private final DataGenerator dataGenerator;
     @Value("${spring.profiles.active:unknown}")
@@ -31,6 +30,8 @@ public class MultiThreadedUpdateTest {
     private CustomerRepository customerRepository;
     @Autowired
     private DatabaseMetrics databaseMetrics;
+    @Autowired
+    private BenchmarkConfig benchmarkConfig;
 
     public MultiThreadedUpdateTest() {
         this.dataGenerator = new DataGenerator();
@@ -38,25 +39,27 @@ public class MultiThreadedUpdateTest {
 
 
     void testMultiThreadedUpdate() throws InterruptedException {
-        log.info("Rozpoczynam test wielowątkowej AKTUALIZACJI ({} wątków)", THREAD_COUNT);
+        int threadCount = benchmarkConfig.getThreads();
+        int totalRecords = benchmarkConfig.getRecordCount();
+        log.info("Rozpoczynam test wielowątkowej AKTUALIZACJI ({} wątków)", threadCount);
 
         List<Customer> allCustomers = customerRepository.findAll();
-        if (allCustomers.size() < TOTAL_RECORDS) {
+        if (allCustomers.size() < totalRecords) {
             log.warn("Brak wystarczającej liczby rekordów do testu, znaleziono: {}", allCustomers.size());
             return;
         }
 
-        ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
-        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
         AtomicInteger successCounter = new AtomicInteger();
         AtomicInteger errorCounter = new AtomicInteger();
 
         List<Long> threadDurations = new CopyOnWriteArrayList<>();
 
         long startTime = System.nanoTime();
-        int recordsPerThread = TOTAL_RECORDS / THREAD_COUNT;
+        int recordsPerThread = totalRecords / threadCount;
 
-        for (int i = 0; i < THREAD_COUNT; i++) {
+        for (int i = 0; i < threadCount; i++) {
             int startIdx = i * recordsPerThread;
             int endIdx = startIdx + recordsPerThread;
             List<Customer> customersSlice = allCustomers.subList(startIdx, endIdx);

--- a/src/main/java/com/benchmarking/dbcomparison/benchmark/index/IndexPerformanceTest.java
+++ b/src/main/java/com/benchmarking/dbcomparison/benchmark/index/IndexPerformanceTest.java
@@ -1,5 +1,6 @@
 package com.benchmarking.dbcomparison.benchmark.index;
 
+import com.benchmarking.dbcomparison.config.BenchmarkConfig;
 import com.benchmarking.dbcomparison.config.DatabaseMetrics;
 import com.benchmarking.dbcomparison.model.Brand;
 import com.benchmarking.dbcomparison.model.Product;
@@ -39,6 +40,8 @@ public class IndexPerformanceTest {
     private ProductCategoryRepository categoryRepository;
     @Autowired
     private DatabaseMetrics databaseMetrics;
+    @Autowired
+    private BenchmarkConfig benchmarkConfig;
     @Value("${spring.profiles.active:unknown}")
     private String activeProfile;
 
@@ -54,7 +57,7 @@ public class IndexPerformanceTest {
         Set<String> usedSkus = new HashSet<>();
 
         List<Product> products = new ArrayList<>(dataGenerator.generateMixedProducts(brand, category,
-                "Pro", "unique", 10000, 0.3));
+                "Pro", "unique", benchmarkConfig.getRecordCount(), 0.3));
 
         productRepository.saveAll(products);
 

--- a/src/main/java/com/benchmarking/dbcomparison/config/BenchmarkConfig.java
+++ b/src/main/java/com/benchmarking/dbcomparison/config/BenchmarkConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "benchmark")
 public class BenchmarkConfig {
     private int recordCount = 1000; // domyślna wartość
+    private int threads = 10;       // domyślna liczba wątków
 
     public int getRecordCount() {
         return recordCount;
@@ -14,5 +15,13 @@ public class BenchmarkConfig {
 
     public void setRecordCount(int recordCount) {
         this.recordCount = recordCount;
+    }
+
+    public int getThreads() {
+        return threads;
+    }
+
+    public void setThreads(int threads) {
+        this.threads = threads;
     }
 }


### PR DESCRIPTION
## Summary
- extend `BenchmarkConfig` with `threads` property bound to `benchmark.threads`
- read record and thread counts from configuration in all multi-threaded benchmarks
- drive index performance data generation from configured record count

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acd7ce5508832bb9acd617e2d80f36